### PR TITLE
Add child_instance_type to alicloud_cen_instance_attachment resources.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ resource "alicloud_cen_instance_attachment" "vpc_attach_1" {
   instance_id              = local.cen_id
   child_instance_id        = var.vpc_id_1
   child_instance_region_id = var.child_instance_region_id_1
+  child_instance_type      = var.child_instance_type
 }
 
 resource "alicloud_cen_instance_attachment" "vpc_attach_2" {
@@ -42,6 +43,7 @@ resource "alicloud_cen_instance_attachment" "vpc_attach_2" {
   instance_id              = local.cen_id
   child_instance_id        = var.vpc_id_2
   child_instance_region_id = var.child_instance_region_id_2
+  child_instance_type      = var.child_instance_type
 }
 
 resource "alicloud_cen_bandwidth_limit" "this" {

--- a/varibales.tf
+++ b/varibales.tf
@@ -132,6 +132,12 @@ variable "child_instance_region_id_2" {
   default     = ""
 }
 
+variable "child_instance_type" {
+  description = "The type of the child instance to attach."
+  type        = string
+  default     = "VPC"
+}
+
 #bandwidth limit
 variable "create_bandwidth_limit" {
   description = "Wether to create bandwidth limit,Default to true."


### PR DESCRIPTION
Referring to #2, I added the `child_instance_type` to the  `alicloud_cen_instance_attachment` in `main.tf` as a variable defined in the `vars.tf` file.